### PR TITLE
fix: configure environment variable loading for ANTHROPIC_API_KEY

### DIFF
--- a/examples/claude-code-web/package.json
+++ b/examples/claude-code-web/package.json
@@ -25,6 +25,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "compression": "^1.8.1",
+    "dotenv": "^17.2.3",
     "express": "^5.1.0",
     "jotai": "^2.15.0",
     "lucide-react": "^0.546.0",

--- a/examples/claude-code-web/src/server/index.ts
+++ b/examples/claude-code-web/src/server/index.ts
@@ -1,3 +1,4 @@
+import "dotenv/config"
 import { createServer } from './server'
 
 const portEnv = process.env.PORT


### PR DESCRIPTION
- Add dotenv dependency to load .env file
- Import dotenv/config in server entry point

This fixes the "Invalid API key" error by ensuring environment variables from .env are loaded before the server starts.

解决 `example/claude-code-web` 无法通过配置 .env 运行的问题